### PR TITLE
Improve os_log_bytes_written implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,15 @@ TBD:
 	hash_index_cells_used
 	additional_pool_alloc
 
+### InnoDB metrics from information_schema
+
+**Warning: This is only available for MariaDB 10.x**
+
+Collected by parsing the output of `SELECT COUNT from INFORMATION_SCHEMA.INNODB_METRICS where name ='os_log_bytes_written';`:
+
+    mysql plugin: Sending value: innodb/os_log_bytes_written=263167952896
+
+
 ### Database size
 
 Collected by parsing the output of `SELECT table_schema 'db_name',  Round(Sum(data_length + index_length) / 1024 / 1024, 0) 'db_size_mb'  FROM   information_schema.tables WHERE table_schema not in ('mysql', 'information_schema', 'performance_schema', 'heartbeat') GROUP  BY table_schema;`:

--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ TBD:
 	hash_index_cells_used
 	additional_pool_alloc
 
+### Database size
+
+Collected by parsing the output of `SELECT table_schema 'db_name',  Round(Sum(data_length + index_length) / 1024 / 1024, 0) 'db_size_mb'  FROM   information_schema.tables WHERE table_schema not in ('mysql', 'information_schema', 'performance_schema', 'heartbeat') GROUP  BY table_schema;`:
+
+    db_size/databasename=14907
+
+The Database size is in MB.
+
 
 ### Master/Slave Status
    

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ TBD:
 
 ### InnoDB metrics from information_schema
 
-**Warning: This is only available for MariaDB 10.x**
+**Warning: This is only available in MariaDB >= 10.x and MySQL >= 5.6.**
 
 Collected by parsing the output of `SELECT COUNT from INFORMATION_SCHEMA.INNODB_METRICS where name ='os_log_bytes_written';`:
 

--- a/mysql.py
+++ b/mysql.py
@@ -582,7 +582,7 @@ def read_callback():
 	
 	mysql_db_size = fetch_mysql_db_size(conn)
 	for key in mysql_db_size:
-            	dispatch_value('db_size', key, mysql_db_size[key], 'counter')
+            	dispatch_value('db_size', key, mysql_db_size[key], 'gauge')
 
 	innodb_status = fetch_innodb_stats(conn)
 	for key in MYSQL_INNODB_STATUS_VARS:

--- a/mysql.py
+++ b/mysql.py
@@ -96,7 +96,7 @@ MYSQL_STATUS_VARS = {
 	'Innodb_row_lock_time': 'counter',
 	'Innodb_row_lock_time_avg': 'gauge',
 	'Innodb_row_lock_time_max': 'gauge',
-	'Innodb_row_lock_waits': 'counter',
+	'Innodb_row_lock_waits': 'gauge',
 	'Innodb_rows_deleted': 'counter',
 	'Innodb_rows_inserted': 'counter',
 	'Innodb_rows_read': 'counter',

--- a/mysql.py
+++ b/mysql.py
@@ -411,8 +411,12 @@ def fetch_mysql_db_size(conn):
 	return stats
 
 def fetch_innodb_os_log_bytes_written(conn):
-	result = mysql_query(conn, "SELECT COUNT from INFORMATION_SCHEMA.INNODB_METRICS where name ='os_log_bytes_written';")
-	stats = result.fetchone()
+	# This feature is only available for mariaDB >= 10.x and MySQL > 5.5.
+	try:
+		result = mysql_query(conn, "SELECT COUNT from INFORMATION_SCHEMA.INNODB_METRICS where name ='os_log_bytes_written';")
+		stats = result.fetchone()
+	except MySQLdb.OperationalError:
+		stats = {'COUNT': 0}
 	return stats
 
 def fetch_mysql_process_states(conn):
@@ -602,8 +606,8 @@ if COLLECTD_ENABLED:
 	 collectd.register_config(configure_callback)
 
 if __name__ == "__main__" and not COLLECTD_ENABLED:
-	print "Running in test mode, invoke with"
-	print sys.argv[0] + " Host Port User Password "
+	print("Running in test mode, invoke with")
+	print(sys.argv[0] + " Host Port User Password ")
 	MYSQL_CONFIG['Host'] = sys.argv[1]
 	MYSQL_CONFIG['Port'] = int(sys.argv[2])
 	MYSQL_CONFIG['User'] = sys.argv[3]

--- a/mysql.py
+++ b/mysql.py
@@ -398,8 +398,8 @@ def fetch_mysql_slave_stats(conn):
 		if 'delay' in row and row['delay'] != None:
 			status['slave_lag'] = row['delay']
 
-	status['slave_running'] = 1 if slave_row['Slave_SQL_Running'] == 'Yes' else 0
-	status['slave_stopped'] = 1 if slave_row['Slave_SQL_Running'] != 'Yes' else 0
+	status['slave_running'] = 1 if slave_row['Slave_SQL_Running'] == 'Yes' and slave_row['Slave_IO_Running'] == 'Yes' else 0
+	status['slave_stopped'] = 1 if slave_row['Slave_SQL_Running'] != 'Yes' or slave_row['Slave_IO_Running'] != 'Yes' else 0
 	return status
 
 def fetch_mysql_process_states(conn):

--- a/mysql.py
+++ b/mysql.py
@@ -410,6 +410,11 @@ def fetch_mysql_db_size(conn):
     		stats[row['db_name']] = row['db_size_mb']
 	return stats
 
+def fetch_innodb_os_log_bytes_written(conn):
+	result = mysql_query(conn, "SELECT COUNT from INFORMATION_SCHEMA.INNODB_METRICS where name ='os_log_bytes_written';")
+	stats = result.fetchone()
+	return stats
+
 def fetch_mysql_process_states(conn):
 	global MYSQL_PROCESS_STATES
 	result = mysql_query(conn, 'SHOW PROCESSLIST')
@@ -583,6 +588,9 @@ def read_callback():
 	mysql_db_size = fetch_mysql_db_size(conn)
 	for key in mysql_db_size:
             	dispatch_value('db_size', key, mysql_db_size[key], 'gauge')
+
+	innodb_log_bytes_written = fetch_innodb_os_log_bytes_written(conn)
+	dispatch_value('innodb', 'os_log_bytes_written', innodb_log_bytes_written['COUNT'], 'counter')
 
 	innodb_status = fetch_innodb_stats(conn)
 	for key in MYSQL_INNODB_STATUS_VARS:

--- a/mysql.py
+++ b/mysql.py
@@ -96,7 +96,7 @@ MYSQL_STATUS_VARS = {
 	'Innodb_row_lock_time': 'counter',
 	'Innodb_row_lock_time_avg': 'gauge',
 	'Innodb_row_lock_time_max': 'gauge',
-	'Innodb_row_lock_waits': 'gauge',
+	'Innodb_row_lock_waits': 'counter',
 	'Innodb_rows_deleted': 'counter',
 	'Innodb_rows_inserted': 'counter',
 	'Innodb_rows_read': 'counter',


### PR DESCRIPTION
The innodb_metrics table is only available since MySQL 5.6 and MariaDB 10.x. This change will prevent this part of the code to raise an error for the MySQL < 5.6 and MariaDB < 10.x